### PR TITLE
Cannot read property 'filter' of undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,10 @@ function emit(name, arg) {
  * @returns {undefined} nothing
  */
 function unsubscribeOf(name, func) {
+  if (!subscribes.has(name)){
+    return;
+  }
+  
   if (func)
     subscribes.set(
       name,

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const subscribes = new Map();
  * @returns {function} unsubscribe function
  */
 function on(name, func) {
-  if (!subscribes.has(name)) subscribes.set(name, []);
+  if (!subscribes.get(name)) subscribes.set(name, []);
   subscribes.get(name).push(func);
   return () => unsubscribeOf(name, func);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const subscribes = new Map();
  * @returns {function} unsubscribe function
  */
 function on(name, func) {
-  if (!subscribes.get(name)) subscribes.set(name, []);
+  if (!subscribes.has(name)) subscribes.set(name, []);
   subscribes.get(name).push(func);
   return () => unsubscribeOf(name, func);
 }


### PR DESCRIPTION
> var mym = new Map();
< undefined

> mym.set("name", "ali")
< Map(1) {"name" => "ali"}

> mym.has("name")
< true

> mym.set("family", undefined)
< Map(2) {"name" => "ali", "family" => undefined}

> mym.has("family")
< true

> !!mym.get("family")
< false

it's true that the 'family' exist but its value is 'undefined' in this case also we need to initialize it with an empty array so I think using '.get' is better than '.has' in this case